### PR TITLE
Add Google image models to AA wizard Step 2

### DIFF
--- a/editor/plugins/ai_assistant/ai_assistant_dock.cpp
+++ b/editor/plugins/ai_assistant/ai_assistant_dock.cpp
@@ -1774,6 +1774,15 @@ void AIAssistantDock::_wizard_populate_image_models() {
 		has_any = true;
 	}
 
+	bool google_connected = wizard_connected.has("google") && wizard_connected["google"];
+	if (google_connected) {
+		wizard_image_model_selector->add_item("Google / nano-banana-2");
+		wizard_image_model_selector->set_item_metadata(wizard_image_model_selector->get_item_count() - 1, "google/nano-banana-2");
+		wizard_image_model_selector->add_item("Google / nano-banana-pro");
+		wizard_image_model_selector->set_item_metadata(wizard_image_model_selector->get_item_count() - 1, "google/nano-banana-pro");
+		has_any = true;
+	}
+
 	// Pre-select based on last known model
 	if (has_any && !wizard_current_image_model.is_empty()) {
 		for (int i = 0; i < wizard_image_model_selector->get_item_count(); i++) {


### PR DESCRIPTION
## Summary
- Add Google Gemini image models (`nano-banana-2`, `nano-banana-pro`) to the AI Assistant setup wizard's image model selector (Step 2)

## Changes
- **Modified**: `editor/plugins/ai_assistant/ai_assistant_dock.cpp` — Add Google image models to `_wizard_populate_image_models()` when Google is connected

## Related Issues
- Closes bluredengine/godot#4
- Part of bluredengine/blured#4

## Test plan
- [ ] Open AA wizard with Google API key connected
- [ ] Verify Step 2 shows Google / nano-banana-2 and Google / nano-banana-pro in image model dropdown
- [ ] Verify selecting a Google model persists through wizard completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)